### PR TITLE
guess_sequence_type bug

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -76,7 +76,6 @@ phy_read <- function(file) {
 
     names(seq_str) <- nm
     ## BStringSet(seq_str)
-
     switch(guess_sequence_type(seq_str[1]),
            DNA = DNAStringSet(seq_str),
            RNA = RNAStringSet(seq_str),
@@ -84,27 +83,31 @@ phy_read <- function(file) {
 }
 
 guess_sequence_type <- function(string) {
-    seqstr <- readLines(string, n=3)
-    if (length(seqstr)==2 || grepl("^>", seqstr[[3]])){
-        # >seq1
-        # AGCGTACGTGACGTAGCGTAGC
-        # >seq2
-        a <- seqstr[2]
-    }else{
-        # >seq1
-        # ---------
-        # AGCG----C
-        # ---------
-        # >seq2
-        seqstr <- readLines(string, n=20)
-        seqind <- grep("^>", seqstr)
-        if (length(seqind)==1){
-            a <- paste0(seqstr[-1], collapse="")
+    if (file.exists(string)){
+        seqstr <- readLines(string, n=3)
+        if (length(seqstr)==2 || grepl("^>", seqstr[[3]])){
+            # >seq1
+            # AGCGTACGTGACGTAGCGTAGC
+            # >seq2
+            a <- seqstr[2]
         }else{
-            inds <- seqind[1] + 1
-            inde <- seqind[2] - 1
-            a <- paste0(seqstr[inds:inde], collapse="")
+            # >seq1
+            # ---------
+            # AGCG----C
+            # ---------
+            # >seq2
+            seqstr <- readLines(string, n=20)
+            seqind <- grep("^>", seqstr)
+            if (length(seqind)==1){
+                a <- paste0(seqstr[-1], collapse="")
+            }else{
+                inds <- seqind[1] + 1
+                inde <- seqind[2] - 1
+                a <- paste0(seqstr[inds:inde], collapse="")
+            }
         }
+    }else{
+        a <- string
     }
     a <- strsplit(toupper(a), split="")[[1]]
     freq1 <- mean(a %in% c('A', 'C', 'G', 'T', 'X', 'N', '-') )


### PR DESCRIPTION
fix a bug about `guess_sequence_type`. when the input is a string, not a file, it will generate an error.

```
> library(seqmagick)
> example(phy_read)

phy_rd> phy_file <- system.file("extdata/HA.phy", package="seqmagick")

phy_rd> phy_read(phy_file)
DNAStringSet object of length 100:
      width seq                                             names               
  [1]  1893 ---------------GGATAAT...---------------------- CY168567 A/Boston...
  [2]  1893 -------------------AAA...---------------------- CY053309 A/Browns...
  [3]  1893 ---AGCAAAAGCAGGGGATAAT...---------------------- LC111587 A/Fukuok...
  [4]  1893 -----------GGGAAAATAAA...---------------------- CY084969 A/swine/...
  [5]  1893 ----------------------...---------------------- EU885538 A/New Yo...
  ...   ... ...
 [96]  1893 ----------------------...---------------------- KC013577 A/swine/...
 [97]  1893 ----------------------...---------------------- GQ385825 A/New Ha...
 [98]  1893 ----------------------...---------------------- CY043768 A/Hong K...
 [99]  1893 ----------------------...---------------------- GU371272 A/Hunan ...
[100]  1893 ----------------------...---------------------- KM208509 A/Hangzh...
```